### PR TITLE
Fix for calling init() outside pod project

### DIFF
--- a/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
+++ b/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
@@ -107,7 +107,7 @@ public class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     ///                          (Default: `.justified`)
     ///   - verticalAlignment:   Specified how the cells are vertically aligned in a row. --
     ///                          (Default: `.center`)
-    init(horizontalAlignment: HorizontalAlignment = .justified, verticalAlignment: VerticalAlignment = .center) {
+    public init(horizontalAlignment: HorizontalAlignment = .justified, verticalAlignment: VerticalAlignment = .center) {
         super.init()
         self.horizontalAlignment = horizontalAlignment
         self.verticalAlignment = verticalAlignment


### PR DESCRIPTION
Nice project, made my life a little easier. I had to make the init call public to be able to init the class in code.

Error:  'AlignedCollectionViewFlowLayout' is inaccessible due to 'internal' protection level