### PR TITLE
Allow inheritance for Swift 3.0+

### DIFF
--- a/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
+++ b/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
@@ -61,7 +61,7 @@ private struct AlignmentAxis<A: Alignment> {
 /// over the horizontal and vertical alignment of the cells.
 /// You can use it to align the cells like words in a left- or right-aligned text
 /// and you can specify how the cells are vertically aligned in their row.
-public class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
+open class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     
     // MARK: - 🔶 Properties
     
@@ -120,7 +120,7 @@ public class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     
     // MARK: - 🅾️ Overrides
     
-    override public func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+    override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
         
         // 💡 IDEA:
         // The approach for computing a cell's frame is to create a rectangle that covers the current line.
@@ -164,7 +164,7 @@ public class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return layoutAttributes
     }
     
-    override public func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+    override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         // We may not change the original layout attributes or UICollectionViewFlowLayout might complain.
         let layoutAttributesObjects = copy(super.layoutAttributesForElements(in: rect))
         layoutAttributesObjects?.forEach({ (layoutAttributes) in


### PR DESCRIPTION
Since Swift 3.0 public classes can't be inherited outside its module so for subclass AlignedCollectionViewFlowLayout is needed to change its access level to *open*