### PR TITLE
Add support for SwiftPM-based dependency managers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "AlignedCollectionViewFlowLayout",
+    products: [
+        .library(name: "AlignedCollectionViewFlowLayout", targets: ["AlignedCollectionViewFlowLayout"])
+    ],
+    targets: [
+        .target(
+            name: "AlignedCollectionViewFlowLayout"
+        )
+    ]
+)


### PR DESCRIPTION
This adds a very basic [SwiftPM](https://github.com/apple/swift-package-manager) manifest file to be compatible with any dependency manager that uses Apples official way of specifying libraries.

Note that I created this PR because I'm currently developing a dependency manager called [Accio](https://github.com/JamitLabs/Accio) which is intended to fix several issues with Carthage and fill the gap between now and the time, when Apple adds official support for SwiftPM into Xcode. Merging this will also prepare for that bright future.